### PR TITLE
chore(hive): explicitly only run prague tests via --sim.limit

### DIFF
--- a/ansible/inventories/devnet-5/group_vars/hive.yaml
+++ b/ansible/inventories/devnet-5/group_vars/hive.yaml
@@ -50,6 +50,7 @@ hive_simulations_tests:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
       #- --sim.timelimit=2h
+      - --sim.limit "fork_CancunToPrague or fork_Prague"
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
   # Consume RLP
   - simulator: ethereum/eest/consume-rlp
@@ -63,6 +64,7 @@ hive_simulations_tests:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
       #- --sim.timelimit=2h
+      - --sim.limit "fork_CancunToPrague or fork_Prague"
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
   # Consume RLP
   - simulator: ethereum/rpc-compat


### PR DESCRIPTION
This PR shouldn't change the current behavior as [pectra-devnet-5@v1.2.0](https://github.com/ethereum/execution-spec-tests/releases/tag/pectra-devnet-5%40v1.2.0) only contains tests filled for `Prague` and the `CancunToPragueAt15k` transition.

It does, however, ensure the current behavior is maintained for this hive instance for upcoming EEST releases that contain tests filled for previously deployed forks, which will be the case when this PR gets merged:
- https://github.com/ethereum/execution-spec-tests/pull/1053

Feel free to disregard this PR, as running tests for all forks might be desirable :laughing: here's what the impact would currently be:
- Prague-only: 4062 tests.
- Until Prague: 6525 tests.
