### PR TITLE
chore: bump eest release to pectra-devnet-5@1.3.0

### DIFF
--- a/ansible/inventories/devnet-5/group_vars/hive.yaml
+++ b/ansible/inventories/devnet-5/group_vars/hive.yaml
@@ -51,6 +51,7 @@ hive_simulations_tests:
       - --sim.parallelism=8
       #- --sim.timelimit=2h
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg branch=pectra-devnet-5@v1.3.0
   # Consume RLP
   - simulator: ethereum/eest/consume-rlp
     clients:
@@ -64,6 +65,7 @@ hive_simulations_tests:
       - --sim.parallelism=8
       #- --sim.timelimit=2h
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg branch=pectra-devnet-5@v1.3.0
   # Consume RLP
   - simulator: ethereum/rpc-compat
     clients:
@@ -77,3 +79,4 @@ hive_simulations_tests:
       - --sim.parallelism=8
       #- --sim.timelimit=2h
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg branch=pectra-devnet-5@v1.3.0

--- a/ansible/inventories/devnet-5/group_vars/hive.yaml
+++ b/ansible/inventories/devnet-5/group_vars/hive.yaml
@@ -50,7 +50,7 @@ hive_simulations_tests:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
       #- --sim.timelimit=2h
-      - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
   # Consume RLP
   - simulator: ethereum/eest/consume-rlp
     clients:
@@ -63,7 +63,7 @@ hive_simulations_tests:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
       #- --sim.timelimit=2h
-      - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
   # Consume RLP
   - simulator: ethereum/rpc-compat
     clients:
@@ -76,4 +76,4 @@ hive_simulations_tests:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
       #- --sim.timelimit=2h
-      - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz


### PR DESCRIPTION
This can only be merged once:
- This github action finishes: https://github.com/ethereum/execution-spec-tests/actions/runs/12932456868
- We publish the release on EEST.

cc @marioevz @skylenet 