### PR TITLE
fix(hive): specify the release tag to use for eest in hive runs

### DIFF
--- a/ansible/inventories/devnet-5/group_vars/hive.yaml
+++ b/ansible/inventories/devnet-5/group_vars/hive.yaml
@@ -51,6 +51,7 @@ hive_simulations_tests:
       - --sim.parallelism=8
       #- --sim.timelimit=2h
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg branch=pectra-devnet-5@v1.2.0
   # Consume RLP
   - simulator: ethereum/eest/consume-rlp
     clients:
@@ -64,6 +65,7 @@ hive_simulations_tests:
       - --sim.parallelism=8
       #- --sim.timelimit=2h
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg branch=pectra-devnet-5@v1.2.0
   # Consume RLP
   - simulator: ethereum/rpc-compat
     clients:
@@ -77,3 +79,4 @@ hive_simulations_tests:
       - --sim.parallelism=8
       #- --sim.timelimit=2h
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.2.0/fixtures_pectra-devnet-5.tar.gz
+      - --sim.buildarg branch=pectra-devnet-5@v1.2.0


### PR DESCRIPTION
This future-proofs consume runs against pyandantic model changes in `main` by ensuring we use a compatible version of EEST sources for consume.