### PR TITLE
update devnet-5 hive flags

### DIFF
--- a/ansible/inventories/devnet-5/group_vars/hive.yaml
+++ b/ansible/inventories/devnet-5/group_vars/hive.yaml
@@ -53,7 +53,7 @@ hive_simulations_tests:
       # - --sim.timelimit=2h
       # - --sim.limit "fork_CancunToPrague or fork_Prague"
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
-      - --sim.buildarg branch=pectra-devnet-5@v1.3.0
+      - --sim.buildarg branch=pectra-devnet-5@v1.3.0post1
   # Consume RLP
   - simulator: ethereum/eest/consume-rlp
     clients:
@@ -68,7 +68,7 @@ hive_simulations_tests:
       # - --sim.timelimit=2h
       # - --sim.limit "fork_CancunToPrague or fork_Prague"
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
-      - --sim.buildarg branch=pectra-devnet-5@v1.3.0
+      - --sim.buildarg branch=pectra-devnet-5@v1.3.0post1
   # Consume RLP
   - simulator: ethereum/rpc-compat
     clients:

--- a/ansible/inventories/devnet-5/group_vars/hive.yaml
+++ b/ansible/inventories/devnet-5/group_vars/hive.yaml
@@ -81,5 +81,3 @@ hive_simulations_tests:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
       # - --sim.timelimit=2h
-      - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
-      - --sim.buildarg branch=pectra-devnet-5@v1.3.0

--- a/ansible/inventories/devnet-5/group_vars/hive.yaml
+++ b/ansible/inventories/devnet-5/group_vars/hive.yaml
@@ -50,8 +50,8 @@ hive_simulations_tests:
     extra_flags:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
-      #- --sim.timelimit=2h
-#       - --sim.limit "fork_CancunToPrague or fork_Prague"
+      # - --sim.timelimit=2h
+      # - --sim.limit "fork_CancunToPrague or fork_Prague"
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
       - --sim.buildarg branch=pectra-devnet-5@v1.3.0
   # Consume RLP
@@ -65,8 +65,8 @@ hive_simulations_tests:
     extra_flags:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
-      #- --sim.timelimit=2h
-#       - --sim.limit "fork_CancunToPrague or fork_Prague"
+      # - --sim.timelimit=2h
+      # - --sim.limit "fork_CancunToPrague or fork_Prague"
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
       - --sim.buildarg branch=pectra-devnet-5@v1.3.0
   # Consume RLP
@@ -80,6 +80,6 @@ hive_simulations_tests:
     extra_flags:
       - --client.checktimelimit=60s
       - --sim.parallelism=8
-      #- --sim.timelimit=2h
+      # - --sim.timelimit=2h
       - --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
       - --sim.buildarg branch=pectra-devnet-5@v1.3.0


### PR DESCRIPTION
Pins the EEST simulator branch to the `pectra-devnet-5@v1.3.0post1` tag to include https://github.com/ethereum/execution-spec-tests/pull/1133 which fixes the Engine API error checks in `eest/consume-engine`.