### PR TITLE
ci(hive): increase jobe timeout from 6h to 9h

### DIFF
--- a/.github/workflows/hive-devnet-5.yaml
+++ b/.github/workflows/hive-devnet-5.yaml
@@ -173,6 +173,7 @@ jobs:
           EOF
 
   test:
+    timeout-minutes: 540 # 9 hours
     needs: prepare
     runs-on: >-
       ${{


### PR DESCRIPTION
as @elasticroentgen nicely found out, there's a default limit of 6h which was causing our runners to cancel long running jobs.

Docs: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes 