### PR TITLE
Nethermind snap sync

### DIFF
--- a/ansible/inventories/devnet-5/group_vars/nethermind.yaml
+++ b/ansible/inventories/devnet-5/group_vars/nethermind.yaml
@@ -33,7 +33,9 @@ nethermind_container_command_extra_args:
   - --JsonRpc.EnabledModules=Eth,Subscribe,Trace,TxPool,Web3,Personal,Proof,Net,Parity,Health,Rpc,Debug,Admin
   - --Discovery.Bootnodes={{ ethereum_el_bootnodes | join(',') }}
   - --Init.IsMining=false
-  - --Pruning.Mode=None
+  - --Sync.FastSync=true
+  - --Sync.SnapSync=true
+  - --Merge.FinalTotalDifficulty=0
   - --config=none
   - --log=INFO
   - --Seq.MinLevel=Info


### PR DESCRIPTION
Nethermind is an archive node by default on devnets, which is fine. However, I would like to test a full node with snap sync as well. The archive node can still remain the default setting.