### PR TITLE
mev: multiple fixes 

### DIFF
--- a/ansible/inventories/devnet-6/group_vars/all/images.yaml
+++ b/ansible/inventories/devnet-6/group_vars/all/images.yaml
@@ -20,7 +20,7 @@ default_ethereum_client_images:
 
 default_tooling_images:
   mev_boost: docker.ethquokkaops.io/dh/ethpandaops/mev-boost:electra
-  mev_boost_relay: docker.ethquokkaops.io/dh/ethpandaops/mev-boost-relay:electra-54c9bf8
+  mev_boost_relay: docker.ethquokkaops.io/dh/ethpandaops/mev-boost-relay:electra-7fd62d4
   xatu_sentry: docker.ethquokkaops.io/dh/ethpandaops/xatu:1.0.25-debian
   ethereum_metrics_exporter: docker.ethquokkaops.io/dh/ethpandaops/ethereum-metrics-exporter:latest
   tx_fuzz: docker.ethquokkaops.io/dh/ethpandaops/tx-fuzz:pr-56

--- a/ansible/inventories/devnet-6/group_vars/all/images.yaml
+++ b/ansible/inventories/devnet-6/group_vars/all/images.yaml
@@ -13,7 +13,7 @@ default_ethereum_client_images:
   erigon: docker.ethquokkaops.io/dh/ethpandaops/erigon:main-4f24e434
   ethereumjs: docker.ethquokkaops.io/dh/ethpandaops/ethereumjs:eip7840
   nethermind: docker.ethquokkaops.io/dh/nethermindeth/nethermind:master-5506f83
-  reth: docker.ethquokkaops.io/dh/ethpandaops/reth:main-46d63e8
+  reth: docker.ethquokkaops.io/dh/ethpandaops/reth:main-dc88fa5
   reth_rbuilder: docker.ethquokkaops.io/dh/ethpandaops/reth-rbuilder:devnet6-fdeb4d6
   nimbusel: docker.ethquokkaops.io/dh/ethpandaops/nimbus-eth1:devnet-6-pectra-82eeb34
   erigonTwo: docker.ethquokkaops.io/dh/ethpandaops/erigon:release-2.61

--- a/ansible/inventories/devnet-6/group_vars/mevrelay.yaml
+++ b/ansible/inventories/devnet-6/group_vars/mevrelay.yaml
@@ -25,7 +25,7 @@ mev_relay_shared_env:
   ELECTRA_FORK_VERSION: "0x60{{ ethereum_genesis_fork_version_suffix }}"
   DB_TABLE_PREFIX: custom
   LOG_LEVEL: debug
-  ENABLE_IGNORE_ALL_VALIDATION_ERRORS: "1"
+  # ENABLE_IGNORE_ALL_VALIDATION_ERRORS: "1"
 
 # ------------------------------------------------------------------
 # mev-relay-housekeeper


### PR DESCRIPTION
- Remove the ENABLE_IGNORE_ALL_VALIDATION_ERRORS env var
- Update  mev-boost-relay service (Justin built a new image which removes debug prints & will not ignore simulation errors).
- Update/restart the reth node the relay uses for simulation (to whatever image works with devnet-6 & contains this fix: https://github.com/paradigmxyz/reth/pull/14405).
- Remove the `ENABLE_IGNORE_ALL_VALIDATION_ERRORS` env var