### PR TITLE
fix(consume): pin a version of eest with the `consume cache` command

### DIFF
--- a/.github/workflows/hive-devnet-6.yaml
+++ b/.github/workflows/hive-devnet-6.yaml
@@ -55,7 +55,7 @@ env:
   S3_PUBLIC_URL: https://hive.ethpandaops.io/pectra-devnet-6
   INSTALL_RCLONE_VERSION: v1.68.2
   EEST_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gz
-  EEST_BUILD_ARG_BRANCH: pectra-devnet-6@v1.0.0
+  EEST_BUILD_ARG_BRANCH: v4.0.0
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
     --client.checktimelimit=60s


### PR DESCRIPTION
A new function to cache the test fixtures in eest containers is now required by ethereum/hive master.

It's not available in pectra-devnet-6@v1.0.0 - this change uses the v4.0.0 branch for the consume command to get `consume cache`.

Tested locally.