### PR TITLE
chore(hive): use `--client.checktimelimit=180s` for besu with 2935 full history

### DIFF
--- a/.github/workflows/hive-devnet-6.yaml
+++ b/.github/workflows/hive-devnet-6.yaml
@@ -58,7 +58,7 @@ env:
   EEST_BUILD_ARG_BRANCH: v4.0.0
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
-    --client.checktimelimit=60s
+    --client.checktimelimit=180s
     --sim.parallelism=4
     --docker.buildoutput
   # Flags used for the ethereum/eest/consume-engine simulator


### PR DESCRIPTION
Besu is timing out after 60s with the EIP-2935 with the full history test case
```
tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py::test_block_hashes_history[fork_Prague-blockchain_test-full_history_plus_one_check_blockhash_first]
```

Btw, locally, this test runs much faster for me. Something to keep an eye on and reduce again, if need be.

Unfortunately, this variable is global - let's add per-client hive flag config in the future!