### PR TITLE
feat(hive): add a new pectra hive workflow

### DIFF
--- a/.github/workflows/hive-devnet-6.yaml
+++ b/.github/workflows/hive-devnet-6.yaml
@@ -1,7 +1,5 @@
 name: Hive - Devnet 6
 on:
-  schedule:
-    - cron: '45 12 * * *'
   workflow_dispatch:
     # Note: We're limited to 10 inputs
     inputs:

--- a/.github/workflows/hive-prague.yaml
+++ b/.github/workflows/hive-prague.yaml
@@ -1,0 +1,260 @@
+name: Hive - Pectra
+on:
+  schedule:
+    - cron: '45 12 * * *'
+  workflow_dispatch:
+    # Note: We're limited to 10 inputs
+    inputs:
+      client:
+        type: string
+        default: '"go-ethereum","reth","nethermind","ethereumjs","nimbus-el","besu","erigon"'
+        description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, ethereumjs, nimbus-el
+      simulator:
+        type: string
+        default: '"ethereum/eest/consume-engine","ethereum/eest/consume-rlp"'
+        description: Comma-separated list of simulators to test .e.g ethereum/rpc-compat, ethereum/eest/consume-engine, ethereum/eest/consume-rlp
+      hive_version:
+        type: string
+        default: ethereum/hive@master
+        description: GitHub repository and tag for hive (repo@tag)
+      geth_version:
+        type: string
+        default: ethereum/go-ethereum@master
+        description: GitHub repository and tag for go-ethereum (repo@tag)
+      besu_version:
+        type: string
+        default: hyperledger/besu@main
+        description: GitHub repository and tag for besu (repo@tag)
+      reth_version:
+        type: string
+        default: paradigmxyz/reth@main
+        description: GitHub repository and tag for reth (repo@tag)
+      nethermind_version:
+        type: string
+        default: NethermindEth/nethermind@master
+        description: GitHub repository and tag for nethermind (repo@tag)
+      erigon_version:
+        type: string
+        default: erigontech/erigon@main
+        description: GitHub repository and tag for erigon (repo@tag)
+      ethereumjs_version:
+        type: string
+        default: ethereumjs/ethereumjs-monorepo@master
+        description: GitHub repository and tag for ethereumjs (repo@tag)
+      nimbusel_version:
+        type: string
+        default: status-im/nimbus-eth1@master
+        description: GitHub repository and tag for nimbus-el (repo@tag)
+
+env:
+  # Proxy
+  GOPROXY: "${{ vars.GOPROXY }}"
+  # Hive action environment variables
+  S3_BUCKET: hive-results
+  S3_PATH: pectra
+  S3_PUBLIC_URL: https://hive.ethpandaops.io/pectra
+  INSTALL_RCLONE_VERSION: v1.68.2
+  EEST_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-spec-tests/releases/download/v4.1.0/fixtures_develop.tar.gz
+  EEST_BUILD_ARG_BRANCH: v4.1.0
+  # Flags used for all simulators
+  GLOBAL_EXTRA_FLAGS: >-
+    --client.checktimelimit=180s
+    --sim.parallelism=4
+    --docker.buildoutput
+  # Flags used for the ethereum/eest/consume-engine simulator
+  EEST_ENGINE_FLAGS: >-
+    --sim.buildarg fixtures=${EEST_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EEST_BUILD_ARG_BRANCH}
+    --sim.loglevel=3
+  # Flags used for the ethereum/eest/consume-rlp simulator
+  EEST_RLP_FLAGS: >-
+    --sim.buildarg fixtures=${EEST_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EEST_BUILD_ARG_BRANCH}
+    --sim.loglevel=3
+  # Flags used for the ethereum/rpc-compat simulator
+  RPC_COMPAT_FLAGS: >-
+    --sim.loglevel=3
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      # Hive version
+      hive_repo: ${{ steps.parse.outputs.hive_repo }}
+      hive_tag: ${{ steps.parse.outputs.hive_tag }}
+      # Versions of the clients
+      geth_repo: ${{ steps.parse.outputs.geth_repo }}
+      geth_tag: ${{ steps.parse.outputs.geth_tag }}
+      geth_docker_image_tag: ${{ steps.parse.outputs.geth_docker_image_tag }}
+      besu_repo: ${{ steps.parse.outputs.besu_repo }}
+      besu_tag: ${{ steps.parse.outputs.besu_tag }}
+      besu_docker_image_tag: ${{ steps.parse.outputs.besu_docker_image_tag }}
+      reth_repo: ${{ steps.parse.outputs.reth_repo }}
+      reth_tag: ${{ steps.parse.outputs.reth_tag }}
+      reth_docker_image_tag: ${{ steps.parse.outputs.reth_docker_image_tag }}
+      nethermind_repo: ${{ steps.parse.outputs.nethermind_repo }}
+      nethermind_tag: ${{ steps.parse.outputs.nethermind_tag }}
+      nethermind_docker_image_tag: ${{ steps.parse.outputs.nethermind_docker_image_tag }}
+      erigon_image: ${{ steps.parse.outputs.erigon_image }}
+      erigon_tag: ${{ steps.parse.outputs.erigon_tag }}
+      erigon_docker_image_tag: ${{ steps.parse.outputs.erigon_docker_image_tag }}
+      ethereumjs_repo: ${{ steps.parse.outputs.ethereumjs_repo }}
+      ethereumjs_tag: ${{ steps.parse.outputs.ethereumjs_tag }}
+      ethereumjs_docker_image_tag: ${{ steps.parse.outputs.ethereumjs_docker_image_tag }}
+      nimbusel_repo: ${{ steps.parse.outputs.nimbusel_repo }}
+      nimbusel_tag: ${{ steps.parse.outputs.nimbusel_tag }}
+      nimbusel_docker_image_tag: ${{ steps.parse.outputs.nimbusel_docker_image_tag }}
+      # client_config contains the YAML client config for Hive
+      client_config: ${{ steps.client_config.outputs.config }}
+    steps:
+      - id: parse
+        run: |
+          # Default client versions
+          GETH_DEFAULT="ethereum/go-ethereum@master"
+          BESU_DEFAULT="hyperledger/besu@main"
+          RETH_DEFAULT="paradigmxyz/reth@main"
+          NETHERMIND_DEFAULT="NethermindEth/nethermind@master"
+          ERIGON_DEFAULT="erigontech/erigon@main"
+          ETHEREUMJS_DEFAULT="ethereumjs/ethereumjs-monorepo@master"
+          NIMBUSEL_DEFAULT="status-im/nimbus-eth1@master"
+          HIVE_DEFAULT="ethereum/hive@master"
+
+          # Parse geth
+          echo "geth_repo=$(echo ${GETH_VERSION:-$GETH_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "geth_tag=$(echo ${GETH_VERSION:-$GETH_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+          echo "geth_docker_image_tag=$(echo ${GETH_VERSION:-$GETH_DEFAULT} | sed 's/[@\/]/_/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+          # Parse besu
+          echo "besu_repo=$(echo ${BESU_VERSION:-$BESU_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "besu_tag=$(echo ${BESU_VERSION:-$BESU_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+          echo "besu_docker_image_tag=$(echo ${BESU_VERSION:-$BESU_DEFAULT} | sed 's/[@\/]/_/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+          # Parse reth
+          echo "reth_repo=$(echo ${RETH_VERSION:-$RETH_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "reth_tag=$(echo ${RETH_VERSION:-$RETH_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+          echo "reth_docker_image_tag=$(echo ${RETH_VERSION:-$RETH_DEFAULT} | sed 's/[@\/]/_/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+          # Parse nethermind
+          echo "nethermind_repo=$(echo ${NETHERMIND_VERSION:-$NETHERMIND_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "nethermind_tag=$(echo ${NETHERMIND_VERSION:-$NETHERMIND_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+          echo "nethermind_docker_image_tag=$(echo ${NETHERMIND_VERSION:-$NETHERMIND_DEFAULT} | sed 's/[@\/]/_/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+          # Parse erigon
+          echo "erigon_repo=$(echo ${ERIGON_VERSION:-$ERIGON_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "erigon_tag=$(echo ${ERIGON_VERSION:-$ERIGON_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+          echo "erigon_docker_image_tag=$(echo ${ERIGON_VERSION:-$ERIGON_DEFAULT} | sed 's/[@\/]/_/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+          # Parse ethereumjs
+          echo "ethereumjs_repo=$(echo ${ETHEREUMJS_VERSION:-$ETHEREUMJS_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "ethereumjs_tag=$(echo ${ETHEREUMJS_VERSION:-$ETHEREUMJS_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+          echo "ethereumjs_docker_image_tag=$(echo ${ETHEREUMJS_VERSION:-$ETHEREUMJS_DEFAULT} | sed 's/[@\/]/_/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+          # Parse nimbusel
+          echo "nimbusel_repo=$(echo ${NIMBUSEL_VERSION:-$NIMBUSEL_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "nimbusel_tag=$(echo ${NIMBUSEL_VERSION:-$NIMBUSEL_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+          echo "nimbusel_docker_image_tag=$(echo ${NIMBUSEL_VERSION:-$NIMBUSEL_DEFAULT} | sed 's/[@\/]/_/g' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+          # Parse hive
+          echo "hive_repo=$(echo ${HIVE_VERSION:-$HIVE_DEFAULT} | cut -d@ -f1)" >> $GITHUB_OUTPUT
+          echo "hive_tag=$(echo ${HIVE_VERSION:-$HIVE_DEFAULT} | cut -d@ -f2)" >> $GITHUB_OUTPUT
+        env:
+          GETH_VERSION: ${{ inputs.geth_version }}
+          BESU_VERSION: ${{ inputs.besu_version }}
+          RETH_VERSION: ${{ inputs.reth_version }}
+          NETHERMIND_VERSION: ${{ inputs.nethermind_version }}
+          ERIGON_VERSION: ${{ inputs.erigon_version }}
+          ETHEREUMJS_VERSION: ${{ inputs.ethereumjs_version }}
+          NIMBUSEL_VERSION: ${{ inputs.nimbusel_version }}
+          HIVE_VERSION: ${{ inputs.hive_version }}
+      - id: client_config
+        run: |
+          cat << 'EOF' >> $GITHUB_OUTPUT
+          config<<ENDCONFIG
+          - client: go-ethereum
+            nametag: default
+            dockerfile: git
+            build_args:
+              github: ${{ steps.parse.outputs.geth_repo }}
+              tag: ${{ steps.parse.outputs.geth_tag }}
+              GOPROXY: ${{ env.GOPROXY }}
+          - client: besu
+            nametag: default
+            dockerfile: git
+            build_args:
+              github: ${{ steps.parse.outputs.besu_repo }}
+              tag: ${{ steps.parse.outputs.besu_tag }}
+          - client: reth
+            nametag: default
+            dockerfile: git
+            build_args:
+              github: ${{ steps.parse.outputs.reth_repo }}
+              tag: ${{ steps.parse.outputs.reth_tag }}
+          - client: nethermind
+            nametag: default
+            dockerfile: git
+            build_args:
+              github: ${{ steps.parse.outputs.nethermind_repo }}
+              tag: ${{ steps.parse.outputs.nethermind_tag }}
+          - client: erigon
+            nametag: default
+            dockerfile: git
+            build_args:
+              github: ${{ steps.parse.outputs.erigon_repo }}
+              tag: ${{ steps.parse.outputs.erigon_tag }}
+              GOPROXY: ${{ env.GOPROXY }}
+          - client: ethereumjs
+            nametag: default
+            dockerfile: git
+            build_args:
+              github: ${{ steps.parse.outputs.ethereumjs_repo }}
+              tag: ${{ steps.parse.outputs.ethereumjs_tag }}
+          - client: nimbus-el
+            nametag: default
+            dockerfile: git
+            build_args:
+              github: ${{ steps.parse.outputs.nimbusel_repo }}
+              tag: ${{ steps.parse.outputs.nimbusel_tag }}
+          ENDCONFIG
+          EOF
+
+  test:
+    timeout-minutes: 540 # 9 hours
+    needs: prepare
+    runs-on: >-
+      ${{
+        matrix.simulator == 'ethereum/rpc-compat' && 'ubuntu-latest' ||
+        contains(matrix.simulator, 'ethereum/eest/') && 'self-hosted-ghr-size-m-x64' ||
+        'ubuntu-latest'
+      }}
+    concurrency:
+      group: >-
+        ${{ github.head_ref || inputs }}-${{ matrix.client }}-${{ matrix.simulator }}
+    strategy:
+      fail-fast: false
+      matrix:
+        client: ${{ fromJSON(format('[{0}]', inputs.client || '"go-ethereum","reth","nethermind","ethereumjs","nimbusel","besu","erigon"')) }}
+        simulator: ${{ fromJSON(format('[{0}]', inputs.simulator || '"ethereum/eest/consume-engine","ethereum/eest/consume-rlp"')) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/hive-deps
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/hive-github-action@master
+        with:
+          hive_repository: ${{ needs.prepare.outputs.hive_repo }}
+          hive_version: ${{ needs.prepare.outputs.hive_tag }}
+          client: ${{ matrix.client }}
+          simulator: ${{ matrix.simulator }}
+          client_config: ${{ needs.prepare.outputs.client_config }}
+          extra_flags: >-
+            ${{ env.GLOBAL_EXTRA_FLAGS }}
+            ${{ matrix.simulator == 'ethereum/rpc-compat' && env.RPC_COMPAT_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eest/consume-engine' && env.EEST_ENGINE_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eest/consume-rlp' && env.EEST_RLP_FLAGS || '' }}
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          s3_public_url: ${{ env.S3_PUBLIC_URL }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          workflow_artifact_upload: true
+          website_upload: false


### PR DESCRIPTION
It'd be nice to have a Hive Pectra dashboard (not fixed to a devnet revision) in the run up to the mainnet fork - this adds an initial version, it's a copy of `.github/workflows/hive-devnet-6.yaml` which:

- Uses main/master for all clients for now (can bump to release branches if required).
- Bumps the EEST fixture release to v4.1.0.
- Run all tests from the fixture release, not just prague.

@skylenet Could you please add the URL and wire the configured s3 path? :pray: 

Todo for a follow-up PR:
- Add a new simulator run: `consume rlp` with ethereum/tests.

