### PR TITLE
chore(hive): increase workflow timeout; use nethermind@release/1.31.5

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -218,7 +218,7 @@ jobs:
           EOF
 
   test:
-    timeout-minutes: 540 # 9 hours
+    timeout-minutes: 720 # 12 hours
     needs: prepare
     runs-on: >-
       ${{

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -31,7 +31,7 @@ on:
         description: GitHub repository and tag for reth (repo@tag)
       nethermind_version:
         type: string
-        default: NethermindEth/nethermind@master
+        default: NethermindEth/nethermind@release/1.31.5
         description: GitHub repository and tag for nethermind (repo@tag)
       erigon_version:
         type: string
@@ -113,7 +113,7 @@ jobs:
           GETH_DEFAULT="ethereum/go-ethereum@master"
           BESU_DEFAULT="hyperledger/besu@main"
           RETH_DEFAULT="paradigmxyz/reth@main"
-          NETHERMIND_DEFAULT="NethermindEth/nethermind@master"
+          NETHERMIND_DEFAULT="NethermindEth/nethermind@release/1.31.5"
           ERIGON_DEFAULT="erigontech/erigon@main"
           ETHEREUMJS_DEFAULT="ethereumjs/ethereumjs-monorepo@master"
           NIMBUSEL_DEFAULT="status-im/nimbus-eth1@master"


### PR DESCRIPTION
- use nethermind@release/1.31.5
- increase workflow timeout (for besu rlp simulator runs)
