### PR TITLE
chore(hive): update erigon timeout consume-rlp

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -247,6 +247,7 @@ jobs:
           client_config: ${{ needs.prepare.outputs.client_config }}
           extra_flags: >-
             ${{ env.GLOBAL_EXTRA_FLAGS }}
+            ${{ matrix.client == 'erigon' && matrix.simulator == 'ethereum/eest/consume-rlp' && '--client.checktimelimit=21600s'}}
             ${{ matrix.simulator == 'ethereum/rpc-compat' && env.RPC_COMPAT_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eest/consume-engine' && env.EEST_ENGINE_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eest/consume-rlp' && env.EEST_RLP_FLAGS || '' }}


### PR DESCRIPTION
Temporarily updates the erigon timeout to 6hrs for consume rlp. Assumes that a second `'--client.checktimelimit=21600s'` flag will override the first.