### PR TITLE
chore(hive): reduce erigon parallelism with consume-engine

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -247,8 +247,8 @@ jobs:
           client_config: ${{ needs.prepare.outputs.client_config }}
           extra_flags: >-
             ${{ env.GLOBAL_EXTRA_FLAGS }}
-            ${{ matrix.client == 'erigon' && matrix.simulator == 'ethereum/eest/consume-rlp' && '--client.checktimelimit=21600s'}}
-            ${{ matrix.client == 'erigon' && matrix.simulator == 'ethereum/eest/consume-engine' && '--sim.parallelism=1'}}
+            ${{ (matrix.client == 'erigon' && matrix.simulator == 'ethereum/eest/consume-rlp') && '--client.checktimelimit=21600s' || '' }}
+            ${{ (matrix.client == 'erigon' && matrix.simulator == 'ethereum/eest/consume-engine') && '--sim.parallelism=1' || '' }}
             ${{ matrix.simulator == 'ethereum/rpc-compat' && env.RPC_COMPAT_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eest/consume-engine' && env.EEST_ENGINE_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eest/consume-rlp' && env.EEST_RLP_FLAGS || '' }}

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -248,6 +248,7 @@ jobs:
           extra_flags: >-
             ${{ env.GLOBAL_EXTRA_FLAGS }}
             ${{ matrix.client == 'erigon' && matrix.simulator == 'ethereum/eest/consume-rlp' && '--client.checktimelimit=21600s'}}
+            ${{ matrix.client == 'erigon' && matrix.simulator == 'ethereum/eest/consume-engine' && '--sim.parallelism=1'}}
             ${{ matrix.simulator == 'ethereum/rpc-compat' && env.RPC_COMPAT_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eest/consume-engine' && env.EEST_ENGINE_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eest/consume-rlp' && env.EEST_RLP_FLAGS || '' }}


### PR DESCRIPTION

### Item 1
Looks like `--sim.parallelism=1` will solve the last Erigon consume-engine fail.

I can't reproduce the erigon 2935 full history fail locally. I.e, this test (e.g. [here](https://hive.ethpandaops.io/pectra/suite.html?suiteid=1744034685-0dd44ebc702a04e9ee42222f43448e46.json&suitename=eest%2Fconsume-engine#test-4782) for
- `tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py::test_block_hashes_history[fork_Prague-blockchain_test_engine-full_history_plus_one_check_blockhash_first]`

In the dashboard results, it seems to fail at very different points in the test/different blocks. Locally, if ran in with `--sim.parallelism 4`, you can observe that the blocks (from this single test and execution) are processed at very different speeds, presumably due to the load from other tests that are running concurrently. 

Erigon also report success running this test in their CI.

### Item 2

Fixes the false return in `extra_flags` from the previous erigon `--sim.timeout`, it seems like for other clients (or erigon engine) this was returning false and not applying the global flags. This resulted is the following reduction in number of tests ran:

<img width="976" alt="Screenshot 2025-04-08 at 18 25 20" src="https://github.com/user-attachments/assets/49b5d60f-f08c-4773-8319-ecd3122640cd" />



