### PR TITLE
chore(hive): fix typo in nimbus-el name

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -1,7 +1,7 @@
 name: Hive - Pectra
 on:
   schedule:
-    - cron: '45 12 * * *'
+    - cron: "45 12 * * *"
   workflow_dispatch:
     # Note: We're limited to 10 inputs
     inputs:
@@ -232,7 +232,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        client: ${{ fromJSON(format('[{0}]', inputs.client || '"go-ethereum","reth","nethermind","ethereumjs","nimbusel","besu","erigon"')) }}
+        client: ${{ fromJSON(format('[{0}]', inputs.client || '"go-ethereum","reth","nethermind","ethereumjs","nimbus-el","besu","erigon"')) }}
         simulator: ${{ fromJSON(format('[{0}]', inputs.simulator || '"ethereum/eest/consume-engine","ethereum/eest/consume-rlp"')) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
I think it needs to match the name used here:
https://github.com/ethpandaops/pectra-devnets/blob/a7290991de6158f91bd377358e7b36fcb0d8852b/.github/workflows/hive.yaml#L10