### PR TITLE
chore(hive/prague): bump nethermind to latest release branch

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -31,7 +31,7 @@ on:
         description: GitHub repository and tag for reth (repo@tag)
       nethermind_version:
         type: string
-        default: NethermindEth/nethermind@release/1.31.6
+        default: NethermindEth/nethermind@release/1.31.7
         description: GitHub repository and tag for nethermind (repo@tag)
       erigon_version:
         type: string
@@ -113,7 +113,7 @@ jobs:
           GETH_DEFAULT="ethereum/go-ethereum@master"
           BESU_DEFAULT="hyperledger/besu@main"
           RETH_DEFAULT="paradigmxyz/reth@main"
-          NETHERMIND_DEFAULT="NethermindEth/nethermind@release/1.31.6"
+          NETHERMIND_DEFAULT="NethermindEth/nethermind@release/1.31.7"
           ERIGON_DEFAULT="erigontech/erigon@main"
           ETHEREUMJS_DEFAULT="ethereumjs/ethereumjs-monorepo@master"
           NIMBUSEL_DEFAULT="status-im/nimbus-eth1@master"


### PR DESCRIPTION
Nethermind have a new release branch, I confirmed with @kamilchodola that we should use this in Hive for now:
https://github.com/NethermindEth/nethermind/tree/release/1.31.7
