### PR TITLE
chore(hive): use nethermind master

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -31,7 +31,7 @@ on:
         description: GitHub repository and tag for reth (repo@tag)
       nethermind_version:
         type: string
-        default: NethermindEth/nethermind@release/1.31.7
+        default: NethermindEth/nethermind@master
         description: GitHub repository and tag for nethermind (repo@tag)
       erigon_version:
         type: string
@@ -113,7 +113,7 @@ jobs:
           GETH_DEFAULT="ethereum/go-ethereum@master"
           BESU_DEFAULT="hyperledger/besu@main"
           RETH_DEFAULT="paradigmxyz/reth@main"
-          NETHERMIND_DEFAULT="NethermindEth/nethermind@release/1.31.7"
+          NETHERMIND_DEFAULT="NethermindEth/nethermind@master"
           ERIGON_DEFAULT="erigontech/erigon@main"
           ETHEREUMJS_DEFAULT="ethereumjs/ethereumjs-monorepo@master"
           NIMBUSEL_DEFAULT="status-im/nimbus-eth1@master"


### PR DESCRIPTION
1.31.8 is already out, but looks primarily like a gnosis release. `master` seems safest for now.