### PR TITLE
Update EEST to v4.4.0

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -54,8 +54,8 @@ env:
   S3_PATH: pectra
   S3_PUBLIC_URL: https://hive.ethpandaops.io/pectra
   INSTALL_RCLONE_VERSION: v1.68.2
-  EEST_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-spec-tests/releases/download/v4.3.0/fixtures_develop.tar.gz
-  EEST_BUILD_ARG_BRANCH: v4.3.0
+  EEST_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_develop.tar.gz
+  EEST_BUILD_ARG_BRANCH: v4.4.0
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
     --client.checktimelimit=180s


### PR DESCRIPTION
Updates EEST version to the latest release [v4.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.4.0).